### PR TITLE
Add missing CI run on pushes to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: "Continuous Integration"
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/{{ cookiecutter.project_name }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_name }}/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: "Continuous Integration Workflow"
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
Add missing CI run on pushes to the main branch for both the cookiecutter and the generated project