### PR TITLE
Add isort and ssort to internal dev tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
 

--- a/{{ cookiecutter.project_name }}/Makefile
+++ b/{{ cookiecutter.project_name }}/Makefile
@@ -3,21 +3,31 @@ GROUP_ID := $(shell id -g)
 
 dev-env:
 	@if [ "$(shell docker image inspect --format='exists' {{ cookiecutter.project_name }}:dev)" != "exists" ]; then docker build --build-arg USER_ID=${USER_ID} --build-arg GROUP_ID=${GROUP_ID} --tag {{ cookiecutter.project_name }}:dev .; fi;
-	@if [ ! -d "__pypackages__" ]; then docker run -t -v "$(PWD):/app" {{ cookiecutter.project_name }}:dev pdm install; docker run -t -v "$(PWD):/app" {{ cookiecutter.project_name }}:dev pdm install --group dev; fi;
+	@if [ ! -d "__pypackages__" ]; then docker run --rm -t -v "$(PWD):/app" {{ cookiecutter.project_name }}:dev pdm install; docker run --rm -t -v "$(PWD):/app" {{ cookiecutter.project_name }}:dev pdm install --group dev; fi;
 
 run: dev-env
 	docker run --rm -v "$(PWD):/app" {{ cookiecutter.project_name }}:dev
 
 bash: dev-env
-	docker run -it -v "$(PWD):/app" {{ cookiecutter.project_name }}:dev bash
+	docker run --rm -it -v "$(PWD):/app" {{ cookiecutter.project_name }}:dev bash
 
 format: dev-env
-	@docker run -t -v "$(PWD):/app" {{ cookiecutter.project_name }}:dev pdm run black .
+	@docker run --rm -t -v "$(PWD):/app" {{ cookiecutter.project_name }}:dev /bin/sh -c " \
+		pdm run ssort {{ cookiecutter.project_name }}/**; \
+		pdm run ssort tests/**; \
+		pdm run isort .; \
+		pdm run black . \
+	"
 
 test: dev-env
-	@docker run -t -v "$(PWD):/app" {{ cookiecutter.project_name }}:dev pdm run pytest --cov={{ cookiecutter.project_name }} tests
-	@docker run -t -v "$(PWD):/app" {{ cookiecutter.project_name }}:dev pdm run mypy
-	@docker run -t -v "$(PWD):/app" {{ cookiecutter.project_name }}:dev pdm run black --check .
+	@docker run --rm -t -v "$(PWD):/app" {{ cookiecutter.project_name }}:dev /bin/sh -c " \
+		pdm run pytest --cov={{ cookiecutter.project_name }} tests; \
+		pdm run mypy; \
+		pdm run ssort --check {{ cookiecutter.project_name }}/**; \
+		pdm run ssort --check tests/**; \
+		pdm run isort --check-only {{ cookiecutter.project_name }}/**; \
+		pdm run isort --check-only .; \
+		pdm run black --check ."
 
 build:
 	@if [ -z ${VERSION} ]; then echo Usage: make build-production VERSION=0.0.0 && exit 1; fi;

--- a/{{ cookiecutter.project_name }}/pdm.lock
+++ b/{{ cookiecutter.project_name }}/pdm.lock
@@ -62,7 +62,7 @@ extras = ["toml"]
 requires_python = ">=3.7"
 summary = "Code coverage measurement for Python"
 dependencies = [
-    "coverage>=5.2.1",
+    "coverage==6.3.1",
     "tomli",
 ]
 
@@ -76,6 +76,12 @@ summary = "Internationalized Domain Names in Applications (IDNA)"
 name = "iniconfig"
 version = "1.1.1"
 summary = "iniconfig: brain-dead simple config-ini parsing"
+
+[[package]]
+name = "isort"
+version = "5.10.1"
+requires_python = ">=3.6.1,<4.0"
+summary = "A Python utility / library to sort Python imports."
 
 [[package]]
 name = "mypy"
@@ -170,6 +176,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssort"
+version = "0.10.0"
+requires_python = ">=3.7"
+summary = "The python statement sorter"
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 requires_python = ">=3.7"
@@ -189,7 +201,7 @@ summary = "HTTP library with thread-safe connection pooling, file post, and more
 
 [metadata]
 lock_version = "3.1"
-content_hash = "sha256:c61e32567155c178d1a81408e751e4ed17bb034c854cedb31374c82ed21a62ba"
+content_hash = "sha256:33b5068952a362b229cdd4f3751e7fab4f568a45df9d6cc100dd7f34a16c184b"
 
 [metadata.files]
 "atomicwrites 1.4.0" = [
@@ -292,6 +304,10 @@ content_hash = "sha256:c61e32567155c178d1a81408e751e4ed17bb034c854cedb31374c82ed
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
+"isort 5.10.1" = [
+    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
+    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
+]
 "mypy 0.931" = [
     {file = "mypy-0.931-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3c5b42d0815e15518b1f0990cff7a705805961613e701db60387e6fb663fe78a"},
     {file = "mypy-0.931-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c89702cac5b302f0c5d33b172d2b55b5df2bede3344a2fbed99ff96bddb2cf00"},
@@ -353,6 +369,9 @@ content_hash = "sha256:c61e32567155c178d1a81408e751e4ed17bb034c854cedb31374c82ed
 "requests 2.27.1" = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
+]
+"ssort 0.10.0" = [
+    {file = "ssort-0.10.0.tar.gz", hash = "sha256:b8cf331202b14fafb162a38d4849dbbef6aa96cdbbcba73e9c732874ebb254e8"},
 ]
 "tomli 2.0.1" = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/{{ cookiecutter.project_name }}/pyproject.toml
+++ b/{{ cookiecutter.project_name }}/pyproject.toml
@@ -17,9 +17,11 @@ homepage = ""
 [project.optional-dependencies]
 dev = [
     "black==22.1.0",
+    "isort==5.10.1",
     "mypy==0.931",
     "pytest-cov==3.0.0",
     "pytest==7.0.0",
+    "ssort==0.10.0",
 ]
 [tool]
 [tool.pdm]


### PR DESCRIPTION
- Add isort and ssort to internal dev tools.
- Drop support for Python 3.7.